### PR TITLE
Run test in newer PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: trusty
+dist: bionic
 
 php:
   - 5.4
@@ -9,6 +9,8 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 before_script:
   - composer self-update


### PR DESCRIPTION
We should confirm if PHP < 7.0 runs on the Bionic Ubuntu Travis (see https://docs.travis-ci.com/user/reference/bionic/#php-support).